### PR TITLE
(chore/add-healthcheck) Add health check endpoints and Docker healthc…

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -73,6 +73,11 @@ services:
       - "--app"
       - "apps.celery_app"
       - "flower"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5555/api/workers').read()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     env_file:
       - .env
 
@@ -92,6 +97,11 @@ services:
       - "--config"
       - "src/apps/flask_app/gunicorn.conf.py"
       - "apps.flask_app:flask_app"
+    healthcheck:
+      test: [ "CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/check').read()" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     env_file:
       - .env
 

--- a/src/apps/flask_app/routes/__init__.py
+++ b/src/apps/flask_app/routes/__init__.py
@@ -1,9 +1,11 @@
 """Routes"""
 
 from .download import download_bp
+from .health import health_bp
 from .hello import hello_bp
 
 
 def register_routes(app):
+    app.register_blueprint(health_bp)
     app.register_blueprint(download_bp)
     app.register_blueprint(hello_bp)

--- a/src/apps/flask_app/routes/download.py
+++ b/src/apps/flask_app/routes/download.py
@@ -6,7 +6,10 @@ from services.download.helpers.task import get_task_result
 from apps.celery_app.tasks.download import download_task
 
 download_bp = Blueprint(
-    "download", __name__, url_prefix="/download", template_folder="templates"
+    name="download",
+    import_name=__name__,
+    url_prefix="/download",
+    template_folder="templates",
 )
 
 

--- a/src/apps/flask_app/routes/health.py
+++ b/src/apps/flask_app/routes/health.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, Response, jsonify
+
+health_bp = Blueprint(name="health", import_name=__name__, url_prefix="/health")
+
+
+@health_bp.get("/check")
+def health_check() -> Response:
+    return jsonify({"status": "ok"})

--- a/src/apps/flask_app/routes/hello.py
+++ b/src/apps/flask_app/routes/hello.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, Response
 
 from config import app_settings
 
-hello_bp = Blueprint("hello", __name__)
+hello_bp = Blueprint(name="hello", import_name=__name__)
 
 
 @hello_bp.get("/")


### PR DESCRIPTION
…hecks

- Add `/health/check` endpoint for service health verification
- Add Docker healthchecks for Flask and Celery services
- Register new health blueprint in Flask route initialization
- Update Blueprint initialization style to use named parameters
- Create new `health.py` route file with health check endpoint