### PR TITLE
fix(youtube-download): improve ffmpeg error logging and config valida…

### DIFF
--- a/src/nmdownloader/config/plugins/youtube.py
+++ b/src/nmdownloader/config/plugins/youtube.py
@@ -8,6 +8,7 @@ class FFMPEGVideoConfig(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
+        validate_by_name=True,
     )
     vcodec: str = "libx264"
     crf: int = Field(default=30, ge=0, le=51)

--- a/src/nmdownloader/services/download/plugins/youtube.py
+++ b/src/nmdownloader/services/download/plugins/youtube.py
@@ -44,13 +44,13 @@ class DownloadYoutube(DownloadBase):
                     ffmpeg.input(filename=_video_path),
                     ffmpeg.input(filename=_audio_path),
                     filename=self.filepath,
-                    **app_settings.downloader.youtube.ffmpeg.model_dump(),
+                    **app_settings.downloader.youtube.ffmpeg.model_dump(by_alias=True),
                 )
                 self.update_status(DownloadStatus.RUNNING, additional="Multiplexage in progress...")
                 output.run(capture_stdout=True, capture_stderr=True)
             except ffmpeg.Error as error:
-                logger.error("stdout: %s", error.stdout.decode())
-                logger.error("stderr: %s", error.stderr.decode())
+                logger.error(f"stdout: {error.stdout.decode()}")
+                logger.error(f"stderr: {error.stderr.decode()}")
                 raise error
             finally:
                 Path(_video_path).unlink(missing_ok=True)


### PR DESCRIPTION
…tion

- Replace string formatting with f-strings for cleaner error logging in youtube.py
- Add `validate_by_name=True` to pydantic model to enforce field name validation
- Ensure ffmpeg config is passed with `by_alias=True` to maintain backward compatibility